### PR TITLE
[FIXED]: [BUG] Size of the search button #35

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -120,7 +120,7 @@ const Hero = () => {
               />
             </div>
             <Button
-              className="bg-primary hover:bg-primary/90 text-white py-2 px-6"
+              className="bg-primary hover:bg-primary/90 text-white p-3 px-6 h-auto"
               type="submit"
             >
               <Search size={18} className="mr-2" /> Search


### PR DESCRIPTION
# 🛠 PR Description

## 🐛 Bug Description
The search button on the Trip&Treat home page is noticeably smaller than the search bar, which affects visual balance.

## 🔄 Steps to Reproduce
1. Go to the Trip&Treat home page.
2. Observe the search button size discrepancy.

## ✅ Expected Behavior
The search button should match the height of the search bar for consistent visual alignment and improved user experience.

## 💡 Changes Made
- Updated the CSS to make the search button height consistent with the search bar.
- Ensured proper padding and margin for alignment.
- Verified responsiveness on different screen sizes.

## 📸 Screenshots
<img width="1146" height="626" alt="image" src="https://github.com/user-attachments/assets/ba7f278b-323c-4ff4-af1a-4ee8a57ee6b0" />


## 📝 Checklist
- [x] I have searched for existing issues before creating this PR.
- [x] I have provided all required information above.
- [x] I have tested this on the latest version.

---

